### PR TITLE
Update to 1.20

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
-	id 'maven-publish'
+	id "fabric-loom" version "1.2-SNAPSHOT"
+	id "maven-publish"
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
-
-archivesBaseName = "${project.archives_base_name}-mc${project.minecraft_version}"
 version = project.mod_version
 group = project.maven_group
+
+base {
+	archivesName = "${project.archives_base_name}-mc${project.minecraft_version}"
+}
 
 dependencies {
 	// To change the versions see the gradle.properties file.
@@ -39,6 +39,9 @@ java {
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task if it is present.
 	// If you remove this line, sources will not be generated.
 	withSourcesJar()
+
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 }
 
 jar {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,15 +2,15 @@
 org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+minecraft_version=1.20
+yarn_mappings=1.20+build.1
+loader_version=0.14.21
 
 # Mod Properties
-mod_version = 1.7
+mod_version = 1.8
 maven_group = net.cavoj
 archives_base_name = servertick
 
 # Mod Dependencies
-fabric_version=0.55.2+1.19
+fabric_version=0.83.0+1.20
 toml4j_version = 0.7.2

--- a/src/main/java/net/cavoj/servertick/mixin/client/DebugHudMixin.java
+++ b/src/main/java/net/cavoj/servertick/mixin/client/DebugHudMixin.java
@@ -2,8 +2,8 @@ package net.cavoj.servertick.mixin.client;
 
 import net.cavoj.servertick.ServerTickClient;
 import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.hud.DebugHud;
-import net.minecraft.client.util.math.MatrixStack;
 import net.minecraft.util.MetricsData;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -14,18 +14,20 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(DebugHud.class)
 public abstract class DebugHudMixin {
-    @Shadow protected abstract void drawMetricsData(MatrixStack matrixStack, MetricsData metricsData, int i, int j, boolean bl);
+    @Shadow protected abstract void drawMetricsData(DrawContext context, MetricsData metricsData, int x, int width, boolean showFps);
 
     @Shadow @Final private MinecraftClient client;
 
     @Inject(method = "render", at = @At("HEAD"))
-    public void render(MatrixStack matrices, CallbackInfo ci) {
+    public void render(DrawContext context, CallbackInfo ci) {
         if (this.client.options.debugTpsEnabled && this.client.getServer() == null) {
             MetricsData metrics = ServerTickClient.getInstance().getMetricsData();
             if (metrics == null) return;
 
-            int i = this.client.getWindow().getScaledWidth();
-            this.drawMetricsData(matrices, metrics, i - Math.min(i / 2, 240), i / 2, false);
+            context.draw(() -> {
+                int i = this.client.getWindow().getScaledWidth();
+                this.drawMetricsData(context, metrics, i - Math.min(i / 2, 240), i / 2, false);
+            });
         }
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,9 +27,9 @@
       "servertick.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.14.6",
+    "fabricloader": ">=0.14.21",
     "fabric": "*",
-    "minecraft": "1.19.x",
+    "minecraft": "1.20.x",
     "java": ">=17"
   }
 }


### PR DESCRIPTION
Updates the mod to 1.20.

Changes in `build.gradle` are for compatibility with Gradle 9, based on changes in the `fabric-example-mod` template. There are also changes in `DebugHudMixin` because it now uses `DrawContext` instead of `MatrixStack`.