### PR TITLE
Fix TPS chart causes text rendering issue

### DIFF
--- a/src/main/java/net/cavoj/servertick/mixin/client/DebugHudMixin.java
+++ b/src/main/java/net/cavoj/servertick/mixin/client/DebugHudMixin.java
@@ -24,7 +24,7 @@ public abstract class DebugHudMixin {
 
     @Shadow private boolean showDebugHud;
 
-    @Inject(method = "render", at = @At(value = "HEAD"))
+    @Inject(method = "method_51746", at = @At(value = "INVOKE", target = "net/minecraft/client/gui/hud/debug/RenderingChart.render(Lnet/minecraft/client/gui/DrawContext;II)V", ordinal = 0))
     private void render(DrawContext context, CallbackInfo ci) {
         if (this.client.getServer() == null &&
                 this.renderingAndTickChartsVisible &&


### PR DESCRIPTION
This is a simple Mixin injection change to fix text rendering issue. TPS Chart should be rendered inside `DrawContext#draw` which is a synthetic method.

Here is a fix applied.
![image](https://github.com/sammko/servertick-fabric/assets/6128413/24f31a78-2b68-46c8-96c3-3b8474e02b73)